### PR TITLE
Split long sections into subdirectories.

### DIFF
--- a/2wiki.sh
+++ b/2wiki.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# I used this script to convert a lost part of section 5 to MediaWiki
+
+for X in `seq 564 569;echo 5610 57;seq 571 575;echo 58;seq 581 584;echo 59; seq 591 599;echo 5910 510`; do curl -O http://archive.adaic.com/ase/ase02_01/bookcase/ada_sh/style95/sec_5/$X.htm ;done
+for X in *.htm; do pandoc -f html -t mediawiki $X -o `basename $X .htm`.wiki; done
+sed -i -e '1,/^-----$/d' *.wiki
+sed -i -e '/^-----$/,$d' *.wiki
+sed -i -e 's#</blockquote>##' -e 's#<blockquote>##' *.wiki
+sed -i -e 's#<span[^>]*>##' -e 's#</span>##' *.wiki
+sed -i -e 's/code>/TT>/g' *.wiki
+sed -i -e "s/'''\([a-z ]*\)'''/==== \1 ====/" *.wiki
+sed -i -e 's/&gt;/>/g' -e 's/&lt;/</g' -e 's/&quot;/"/g' *.wiki
+sed -i -e 's#<pre>#<syntaxhighlight lang=ada>\n#' -e 's#</pre>#\n</syntaxhighlight>#' *.wiki
+sed -i -e "s/'''[0-9.]* \([A-Za-z ]*\)'''/=== \1 ===/" *.wiki
+sed -i -e "s/=== [0-9.]* \([A-Za-z ]*\) ===/== \1 ==/" ??.wiki
+sed -i -e '/toc.htm/,/^$/d' *.wiki
+sed -i -e 's/\[\[[^|]*|\([^]]*\)\]\]/\1/g' *.wiki
+sed -i -e '/<br \/>/{N;s/^/* /;s/^\* -/**/;s#<br />\n##}' *.wiki
+sed -i -e '/^\*/{N;s/\n$//}' *.wiki
+
+for X in `seq 564 569;echo 5610 57;seq 571 575;echo 58;seq 581 584;echo 59; seq 591 599;echo 5910 510`;do cat $X.wiki; done > /tmp/result.wiki
+
+# fix  '=== erroneous ===', upper cases headers ??.wiki, missing list item markers, 

--- a/fetch.sh
+++ b/fetch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
+
 set -e
+ulimit -s unlimited # To fix stack overflow on a large JSON input
 
 OUTPUT=${1:-/tmp/src/ada-lang-io/docs/style-guide}
 AQS2MDX=./bin/aqs2mdx
@@ -19,14 +21,35 @@ for J in $CHAPTERS; do
     # Use quote markdown
     sed -i -e 's/^QUOTE/>/' /tmp/mdx
     # Create front matter
+    SECTION="${INDEX}. ${J//_/ }"
+    if [[ ${INDEX} -eq 11 ]] ; then SECTION="11. Complete Example" ; fi
+    if [[ ${INDEX} -gt 11 ]] ; then SECTION="${J//_/ }" ; fi
     cat > /tmp/front_matter <<-EOF
 ---
-title: ${J//_/ }
-sidebar_position: $INDEX
+title: ${SECTION}
+sidebar_position: ${INDEX}
 ---
 
 EOF
     cat /tmp/front_matter /tmp/mdx note.mdx > $OUTPUT/$J.mdx
+    if [[ ${INDEX} -ge 3 ]] && [[ ${INDEX} -le 10 ]] ; then
+       mkdir $OUTPUT/s${INDEX}
+       mv $OUTPUT/$J.mdx $OUTPUT/s${INDEX}/$J
+       cd $OUTPUT/s${INDEX}
+       csplit -s -f "" $J '/^## /' '{*}'
+       rm $J
+       for X in * ; do
+          mv $X $X.mdx;
+          if [[ $X != 00 ]] ; then
+             #  Turn subsection header into front matter
+             sed -i -e '/^## /i---' -e '/^## /a---' \
+                 -e "/^## /s/^##/title: ${INDEX}.${X#0}/" $X.mdx
+          fi
+       done
+       # Rename top section file to match the folder name
+       mv 00.mdx s${INDEX}.mdx
+       cd - > /dev/null
+    fi
     INDEX=$((INDEX+1))
 done
 
@@ -35,7 +58,6 @@ cat > /tmp/front_matter <<-EOF
 ---
 title: Ada Quality and Style Guide
 description: Guidelines for Professional Programmers
-sidebar_position: 0
 ---
 
 > **_Guidelines for Professional Programmers_**
@@ -46,3 +68,6 @@ sed -e '/<noinclude>/,/<.noinclude>/d' data/Ada_Style_Guide.wiki |
     pandoc -f mediawiki -t gfm --filter ./bin/aqs2mdx  > /tmp/mdx
 
 cat /tmp/front_matter /tmp/mdx note.mdx > $OUTPUT/Ada_Style_Guide.mdx
+
+echo From ada-lang-io repo-folder run:
+echo yarn prettier --write $OUTPUT


### PR DESCRIPTION
I've found, that wikibook has just part of Section 5, so I converted missing text from html and put it on the wikibook. I put here the conversion script just in case. Probably we can reuse it if we will work on restoring links present in HTML, but lost on wikibook.