### PR TITLE
Add options for multi column code examples

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -58,6 +58,7 @@ cat > /tmp/front_matter <<-EOF
 ---
 title: Ada Quality and Style Guide
 description: Guidelines for Professional Programmers
+sidebar_position: 0
 ---
 
 > **_Guidelines for Professional Programmers_**

--- a/source/aqs2mdx.adb
+++ b/source/aqs2mdx.adb
@@ -104,7 +104,8 @@ procedure Aqs2mdx is
             --  in .md
             declare
                --  Table structure in pandoc-types-1.23.1. See
-               --  https://hackage.haskell.org/package/pandoc-types-1.23.1/docs/
+               --  https://hackage.haskell.org/package/pandoc-types-1.23.1/
+               --  docs/
                --  Text-Pandoc-Definition.html
                --
                --  Table:
@@ -138,6 +139,16 @@ procedure Aqs2mdx is
                Cell_List : constant League.JSON.Arrays.JSON_Array :=
                  Row (2).To_Array;
 
+               Columns_Div : Pandoc.Content_Arr (1 .. Cell_List.Length);
+
+               Outer_Attr : constant League.JSON.Values.JSON_Value :=
+                 Pandoc.Attr (
+                    +"", ( 1 => +"className"), ( 1 => +"multi-column"));
+
+               Inner_Attr : constant League.JSON.Values.JSON_Value :=
+                 Pandoc.Attr (
+                    +"", ( 1 => +"className"), ( 1 => +"multi-column-child"));
+
             begin
                pragma Assert (Content.Length = 6);
                pragma Assert (Table_Body_List.Length = 1);
@@ -152,16 +163,17 @@ procedure Aqs2mdx is
                      Cell : constant League.JSON.Arrays.JSON_Array :=
                        Cell_List (J).To_Array;
 
-                     Block_List : constant League.JSON.Arrays.JSON_Array :=
-                       Cell (5).To_Array;
+                     Block_List : constant League.JSON.Values.JSON_Value :=
+                       Cell (5);
+
                   begin
                      pragma Assert (Cell.Length = 5);
 
-                     for K in 1 .. Block_List.Length loop
-                        List.Append (Block_List (K));
-                     end loop;
+                     Columns_Div (J) := Pandoc.Div (Inner_Attr, Block_List);
                   end;
                end loop;
+
+               List.Append (Pandoc.Div (Outer_Attr, Columns_Div));
             end;
          when Block_Header =>
             if Block (Pandoc.Content_String).To_Array.Element (1)

--- a/source/aqs2mdx.adb
+++ b/source/aqs2mdx.adb
@@ -165,7 +165,7 @@ procedure Aqs2mdx is
             end;
          when Block_Header =>
             if Block (Pandoc.Content_String).To_Array.Element (1)
-              .To_Integer = 2
+                .To_Integer = 2
               and then Block (Pandoc.Content_String).To_Array.Element (2)
                 .To_Array.Element (1).To_String = +"introduction"
               --  This relies on the fact that Pandoc converts a title

--- a/source/aqs2mdx.adb
+++ b/source/aqs2mdx.adb
@@ -7,9 +7,12 @@ with League.JSON.Objects;
 with League.JSON.Values;
 with League.Strings;
 
+with Pandoc;
+
 procedure Aqs2mdx is
    use type League.Strings.Universal_String;
    use type League.Holders.Universal_Integer;
+   use all type Pandoc.Object_Type;
 
    function "+" (T : Wide_Wide_String) return League.Strings.Universal_String
       renames League.Strings.To_Universal_String;
@@ -93,97 +96,105 @@ procedure Aqs2mdx is
      return League.JSON.Arrays.JSON_Array
    is
       List : League.JSON.Arrays.JSON_Array;
+      Pandoc_Type : constant Pandoc.Object_Type := Pandoc.Get_Type (Block);
    begin
-      if Block (+"t").To_String.To_Wide_Wide_String = "Table" then
-         --  Flatting tables because no multiline tables in .md
+      case Pandoc_Type is
+         when Block_Table =>
+            --  Flatten tables since there are no native multiline tables
+            --  in .md
+            declare
+               --  Table structure in pandoc-types-1.23.1. See
+               --  https://hackage.haskell.org/package/pandoc-types-1.23.1/docs/
+               --  Text-Pandoc-Definition.html
+               --
+               --  Table:
+               --  Attr Caption [ColSpec] TableHead [TableBody] TableFoot
+               --  1    2       3         4         5           6
 
-         declare
-            --  Table structure in pandoc-types-1.23.1. See
-            --  https://hackage.haskell.org/package/pandoc-types-1.23.1/docs/
-            --  Text-Pandoc-Definition.html
-            --
-            --  Table:
-            --  Attr Caption [ColSpec] TableHead [TableBody] TableFoot
-            --  1    2       3         4         5           6
+               Content : constant League.JSON.Arrays.JSON_Array :=
+                 Block (Pandoc.Content_String).To_Array;
 
-            Content : constant League.JSON.Arrays.JSON_Array :=
-              Block (+"c").To_Array;
+               Table_Body_List : constant League.JSON.Arrays.JSON_Array :=
+                 Content (5).To_Array;
 
-            Table_Body_List : constant League.JSON.Arrays.JSON_Array :=
-              Content (5).To_Array;
-            --  A body of a table, with an intermediate head, intermediate
-            --  body, and the specified number of row header columns in the
-            --  intermediate body.
-            --
-            --  TableBody Attr RowHeadColumns [Row] [Row]
-            --            1    2              3     4
+               --  A body of a table, with an intermediate head, intermediate
+               --  body, and the specified number of row header columns in the
+               --  intermediate body.
+               --
+               --  TableBody Attr RowHeadColumns [Row] [Row]
+               --            1    2              3     4
+               Table_Body : constant League.JSON.Arrays.JSON_Array :=
+                 Table_Body_List (1).To_Array;
 
-            Table_Body : constant League.JSON.Arrays.JSON_Array :=
-              Table_Body_List (1).To_Array;
+               Row_List : constant League.JSON.Arrays.JSON_Array :=
+                 Table_Body (4).To_Array;
 
-            Row_List : constant League.JSON.Arrays.JSON_Array :=
-              Table_Body (4).To_Array;
+               --  A table row.
+               --  Row Attr [Cell]
+               --      1    2
+               Row : constant League.JSON.Arrays.JSON_Array :=
+                 Row_List (1).To_Array;
 
-            Row : constant League.JSON.Arrays.JSON_Array :=
-              Row_List (1).To_Array;
-            --  A table row.
-            --  Row Attr [Cell]
-            --      1    2
+               Cell_List : constant League.JSON.Arrays.JSON_Array :=
+                 Row (2).To_Array;
 
-            Cell_List : constant League.JSON.Arrays.JSON_Array :=
-              Row (2).To_Array;
+            begin
+               pragma Assert (Content.Length = 6);
+               pragma Assert (Table_Body_List.Length = 1);
+               pragma Assert (Row_List.Length = 1);
+               pragma Assert (Cell_List.Length <= 3);
 
-         begin
-            pragma Assert (Content.Length = 6);
-            pragma Assert (Table_Body_List.Length = 1);
-            pragma Assert (Row_List.Length = 1);
-            pragma Assert (Cell_List.Length <= 3);
+               for J in 1 .. Cell_List.Length loop
+                  declare
+                     --  A table cell.
+                     --  Cell Attr Alignment RowSpan ColSpan [Block]
+                     --       1    2         3       4       5
+                     Cell : constant League.JSON.Arrays.JSON_Array :=
+                       Cell_List (J).To_Array;
 
-            for J in 1 .. Cell_List.Length loop
+                     Block_List : constant League.JSON.Arrays.JSON_Array :=
+                       Cell (5).To_Array;
+                  begin
+                     pragma Assert (Cell.Length = 5);
+
+                     for K in 1 .. Block_List.Length loop
+                        List.Append (Block_List (K));
+                     end loop;
+                  end;
+               end loop;
+            end;
+         when Block_Header =>
+            if Block (Pandoc.Content_String).To_Array.Element (1)
+              .To_Integer = 2
+              and then Block (Pandoc.Content_String).To_Array.Element (2)
+                .To_Array.Element (1).To_String = +"introduction"
+              --  This relies on the fact that Pandoc converts a title
+              --  From mediawiki and adds a lower-case id to the header
+            then
+               --  Drop toplevel 'Introduction' section header
+               null;
+            else
+               List.Append (Block.To_JSON_Value);
+            end if;
+         when Inline_Link =>
+            List.Append (Traverse_Link (Block));
+         when others =>
+            if Block (Pandoc.Content_String).To_Array.Length > 0 then
                declare
-                  Cell : constant League.JSON.Arrays.JSON_Array :=
-                     Cell_List (J).To_Array;
-                  --  A table cell.
-                  --  Cell Attr Alignment RowSpan ColSpan [Block]
-                  --       1    2         3       4       5
-
-                  Block_List : constant League.JSON.Arrays.JSON_Array :=
-                    Cell (5).To_Array;
+                  --  Traverse nested blocks
+                  Copy : League.JSON.Objects.JSON_Object := Block;
+                  Arr : constant League.JSON.Arrays.JSON_Array :=
+                    Block (Pandoc.Content_String).To_Array;
                begin
-                  pragma Assert (Cell.Length = 5);
-
-                  for K in 1 .. Block_List.Length loop
-                     List.Append (Block_List (K));
-                  end loop;
+                  Copy.Insert (
+                     Pandoc.Content_String,
+                     Traverse_List (Arr).To_JSON_Value);
+                  List.Append (Copy.To_JSON_Value);
                end;
-            end loop;
-         end;
-
-      elsif Block (+"t").To_String.To_Wide_Wide_String = "Header"
-        and then Block (+"c").To_Array.Element (1).To_Integer = 2
-        and then Block (+"c").To_Array.Element (2)
-          .To_Array.Element (1).To_String = +"introduction"
-      then
-         --  Drop toppest 'Introduction' section header
-         null;
-
-      elsif Block (+"t").To_String.To_Wide_Wide_String = "Link" then
-         List.Append (Traverse_Link (Block));
-
-      elsif Block (+"c").To_Array.Length > 0 then
-         declare
-            --  Traverse nested blocks
-            Copy : League.JSON.Objects.JSON_Object := Block;
-         begin
-            Copy.Insert
-              (+"c", Traverse_List (Block (+"c").To_Array).To_JSON_Value);
-
-            List.Append (Copy.To_JSON_Value);
-         end;
-
-      else  --  Something else (if any?)
-         List.Append (Block.To_JSON_Value);
-      end if;
+            else
+               List.Append (Block.To_JSON_Value);
+            end if;
+      end case;
 
       return List;
    end Traverse_Block;

--- a/source/pandoc.adb
+++ b/source/pandoc.adb
@@ -1,6 +1,89 @@
-with League.JSON.Values;
+with League.JSON.Arrays;
 
 package body Pandoc is
+
+   function Attr (
+      Id : Ustr.Universal_String;
+      Key : Ustr_Array;
+      Value : Ustr_Array) return League.JSON.Values.JSON_Value
+   is
+      Outer : League.JSON.Arrays.JSON_Array;
+      Other : League.JSON.Arrays.JSON_Array;
+      Inner : League.JSON.Arrays.JSON_Array;
+   begin
+      Outer.Append (League.JSON.Values.To_JSON_Value (Id));
+      Outer.Append (Other.To_JSON_Value);
+
+      for K in Key'Range loop
+         declare
+            Pair : League.JSON.Arrays.JSON_Array;
+         begin
+            Pair.Append (League.JSON.Values.To_JSON_Value (Key (K)));
+            Pair.Append (League.JSON.Values.To_JSON_Value (Value (K)));
+            Inner.Append (Pair.To_JSON_Value);
+         end;
+      end loop;
+
+      Outer.Append (Inner.To_JSON_Value);
+
+      return Outer.To_JSON_Value;
+   end Attr;
+
+   function Div (
+      Attr : League.JSON.Values.JSON_Value;
+      Content : Content_Arr) return League.JSON.Values.JSON_Value
+   is
+      Block : League.JSON.Objects.JSON_Object;
+      Out_Content : League.JSON.Arrays.JSON_Array;
+      Content_Block : League.JSON.Arrays.JSON_Array;
+   begin
+      Block.Insert (
+         Type_String,
+         League.JSON.Values.To_JSON_Value (
+            Obj_String_Representation (Block_Div)
+         )
+      );
+
+      for C in Content'Range loop
+         Content_Block.Append (Content (C));
+      end loop;
+
+      Out_Content.Append (Attr);
+      Out_Content.Append (Content_Block.To_JSON_Value);
+
+      Block.Insert (
+         Content_String,
+         Out_Content.To_JSON_Value
+      );
+
+      return Block.To_JSON_Value;
+   end Div;
+
+   function Div (
+      Attr : League.JSON.Values.JSON_Value;
+      Content : League.JSON.Values.JSON_Value)
+      return League.JSON.Values.JSON_Value
+   is
+      Block : League.JSON.Objects.JSON_Object;
+      Out_Content : League.JSON.Arrays.JSON_Array;
+   begin
+      Block.Insert (
+         Type_String,
+         League.JSON.Values.To_JSON_Value (
+            Obj_String_Representation (Block_Div)
+         )
+      );
+
+      Out_Content.Append (Attr);
+      Out_Content.Append (Content);
+
+      Block.Insert (
+         Content_String,
+         Out_Content.To_JSON_Value
+      );
+
+      return Block.To_JSON_Value;
+   end Div;
 
    function Get_Type (B : League.JSON.Objects.JSON_Object)
      return Object_Type is

--- a/source/pandoc.adb
+++ b/source/pandoc.adb
@@ -1,0 +1,32 @@
+with League.JSON.Values;
+
+package body Pandoc is
+
+   function Get_Type (B : League.JSON.Objects.JSON_Object)
+     return Object_Type is
+   begin
+      return Type_Map.Element (
+        Type_Mapping.Find (
+          B (Type_String).To_String
+        )
+      );
+   end Get_Type;
+
+   function Hash (Item : Ustr.Universal_String)
+     return Ada.Containers.Hash_Type is
+   begin
+      return Ada.Containers.Hash_Type (League.Hash_Type'(Item.Hash));
+   end Hash;
+
+begin
+
+   for Key in Object_Type loop
+      declare
+         Str_Rep : constant Ustr.Universal_String :=
+           Obj_String_Representation (Key);
+      begin
+         Type_Mapping.Insert (Str_Rep, Key);
+      end;
+   end loop;
+
+end Pandoc;

--- a/source/pandoc.ads
+++ b/source/pandoc.ads
@@ -2,6 +2,7 @@ with Ada.Containers;
 with Ada.Containers.Hashed_Maps;
 with League.JSON.Objects;
 with League.Strings;
+with League.JSON.Values;
 
 package Pandoc is
 
@@ -48,11 +49,28 @@ package Pandoc is
      Inline_Span
     );
 
+   type Content_Arr is array (Natural range <>)
+     of League.JSON.Values.JSON_Value;
+
    function Get_Type (
      B : League.JSON.Objects.JSON_Object) return Object_Type;
 
    function "+" (T : Wide_Wide_String) return Ustr.Universal_String
      renames Ustr.To_Universal_String;
+
+   function Attr (
+      Id : Ustr.Universal_String;
+      Key : Ustr_Array;
+      Value : Ustr_Array) return League.JSON.Values.JSON_Value;
+
+   function Div (
+      Attr : League.JSON.Values.JSON_Value;
+      Content : Content_Arr) return League.JSON.Values.JSON_Value;
+
+   function Div (
+      Attr : League.JSON.Values.JSON_Value;
+      Content : League.JSON.Values.JSON_Value)
+      return League.JSON.Values.JSON_Value;
 
    Type_String : constant Ustr.Universal_String := +"t";
    Content_String : constant Ustr.Universal_String := +"c";
@@ -63,7 +81,7 @@ private
      return Ada.Containers.Hash_Type;
 
    Obj_String_Representation :
-     constant array (Object_Type) of Ustr.Universal_String := (
+     constant array (Object_Type) of Ustr.Universal_String := [
       +"Plain",
       +"Para",
       +"LineBlock",
@@ -98,7 +116,7 @@ private
       +"Image",
       +"Note",
       +"Span"
-    );
+   ];
 
    package Type_Map is new Ada.Containers.Hashed_Maps (
      Key_Type => Ustr.Universal_String,

--- a/source/pandoc.ads
+++ b/source/pandoc.ads
@@ -1,12 +1,15 @@
 with Ada.Containers;
 with Ada.Containers.Hashed_Maps;
-with League.Strings;
-with League.JSON;
 with League.JSON.Objects;
+with League.Strings;
 
 package Pandoc is
 
+   Pandoc_Type_Error : exception;
+
    package Ustr renames League.Strings;
+
+   type Ustr_Array is array (Natural range <>) of Ustr.Universal_String;
 
    type Object_Type is (
      Block_Plain,
@@ -56,6 +59,9 @@ package Pandoc is
 
 private
 
+   function Hash (Item : Ustr.Universal_String)
+     return Ada.Containers.Hash_Type;
+
    Obj_String_Representation :
      constant array (Object_Type) of Ustr.Universal_String := (
       +"Plain",
@@ -93,9 +99,6 @@ private
       +"Note",
       +"Span"
     );
-
-   function Hash (Item : Ustr.Universal_String)
-     return Ada.Containers.Hash_Type;
 
    package Type_Map is new Ada.Containers.Hashed_Maps (
      Key_Type => Ustr.Universal_String,

--- a/source/pandoc.ads
+++ b/source/pandoc.ads
@@ -81,7 +81,7 @@ private
      return Ada.Containers.Hash_Type;
 
    Obj_String_Representation :
-     constant array (Object_Type) of Ustr.Universal_String := [
+     constant array (Object_Type) of Ustr.Universal_String := (
       +"Plain",
       +"Para",
       +"LineBlock",
@@ -116,7 +116,7 @@ private
       +"Image",
       +"Note",
       +"Span"
-   ];
+   );
 
    package Type_Map is new Ada.Containers.Hashed_Maps (
      Key_Type => Ustr.Universal_String,

--- a/source/pandoc.ads
+++ b/source/pandoc.ads
@@ -1,0 +1,108 @@
+with Ada.Containers;
+with Ada.Containers.Hashed_Maps;
+with League.Strings;
+with League.JSON;
+with League.JSON.Objects;
+
+package Pandoc is
+
+   package Ustr renames League.Strings;
+
+   type Object_Type is (
+     Block_Plain,
+     Block_Para,
+     Block_LineBlock,
+     Block_CodeBlock,
+     Block_RawBlock,
+     Block_BlockQuote,
+     Block_OrderedList,
+     Block_BulletList,
+     Block_DefinitionList,
+     Block_Header,
+     Block_HorizontalRule,
+     Block_Table,
+     Block_Figure,
+     Block_Div,
+     Inline_String,
+     Inline_Emph,
+     Inline_Underline,
+     Inline_Strong,
+     Inline_Strikeout,
+     Inline_Superscript,
+     Inline_Subscript,
+     Inline_SmallCaps,
+     Inline_Quoted,
+     Inline_Cite,
+     Inline_Code,
+     Inline_Space,
+     Inline_SoftBreak,
+     Inline_LineBreak,
+     Inline_Math,
+     Inline_RawInline,
+     Inline_Link,
+     Inline_Image,
+     Inline_Note,
+     Inline_Span
+    );
+
+   function Get_Type (
+     B : League.JSON.Objects.JSON_Object) return Object_Type;
+
+   function "+" (T : Wide_Wide_String) return Ustr.Universal_String
+     renames Ustr.To_Universal_String;
+
+   Type_String : constant Ustr.Universal_String := +"t";
+   Content_String : constant Ustr.Universal_String := +"c";
+
+private
+
+   Obj_String_Representation :
+     constant array (Object_Type) of Ustr.Universal_String := (
+      +"Plain",
+      +"Para",
+      +"LineBlock",
+      +"CodeBlock",
+      +"RawBlock",
+      +"BlockQuote",
+      +"OrderedList",
+      +"BulletList",
+      +"DefinitionList",
+      +"Header",
+      +"HorizontalRule",
+      +"Table",
+      +"Figure",
+      +"Div",
+      +"Str",
+      +"Emph",
+      +"Underline",
+      +"Strong",
+      +"Strikeout",
+      +"Superscript",
+      +"Subscript",
+      +"SmallCaps",
+      +"Quoted",
+      +"Cite",
+      +"Code",
+      +"Space",
+      +"SoftBreak",
+      +"LineBreak",
+      +"Math",
+      +"RawInline",
+      +"Link",
+      +"Image",
+      +"Note",
+      +"Span"
+    );
+
+   function Hash (Item : Ustr.Universal_String)
+     return Ada.Containers.Hash_Type;
+
+   package Type_Map is new Ada.Containers.Hashed_Maps (
+     Key_Type => Ustr.Universal_String,
+     Element_Type => Object_Type,
+     Hash => Hash,
+     Equivalent_Keys => Ustr."=");
+
+   Type_Mapping : Type_Map.Map := Type_Map.Empty;
+
+end Pandoc;


### PR DESCRIPTION
This pull requests changes the way that tables are filtered by the aqs2mdx filter. It extracts the
the content from all columns in the first row of the table, and then places it in nested div's.

The current state of the filter outputs:

```html

Code example

Code example

```

and the code in this pull requests outputs:

```html
<div className="multi-column">
   <div className="mutli-column-child">
      Code example
   </div>
   <div className="multi-column-child">
      Code example
   </div>
</div>
```

The css can then be changed to make `multi-column` a flexbox.

A secondary change is the addition of a sidebar position for the `Ada_Style_Guide.mdx` file, which will place
the file at the top of book.