### PR TITLE
Fix links without text

### DIFF
--- a/source/aqs2mdx.adb
+++ b/source/aqs2mdx.adb
@@ -38,6 +38,9 @@ procedure Aqs2mdx is
    Wikibook : constant League.Strings.Universal_String :=
      +"https://en.wikibooks.org/wiki/";
 
+   ClassName : constant League.Strings.Universal_String :=
+     +"className";
+
    ---------------
    -- Read_JSON --
    ---------------
@@ -142,10 +145,10 @@ procedure Aqs2mdx is
                Columns_Div : Pandoc.Content_Arr (1 .. Cell_List.Length);
 
                Outer_Attr : constant League.JSON.Values.JSON_Value :=
-                 Pandoc.Attr (+"className", +"multi-column");
+                 Pandoc.Attr (ClassName, +"multi-column");
 
                Inner_Attr : constant League.JSON.Values.JSON_Value :=
-                 Pandoc.Attr (+"className", +"multi-column-child");
+                 Pandoc.Attr (ClassName, +"multi-column-child");
 
             begin
                pragma Assert (Content.Length = 6);
@@ -209,7 +212,9 @@ procedure Aqs2mdx is
       return List;
    end Traverse_Block;
 
-   function Fix_Wikilink (Target : League.Strings.Universal_String) return League.Strings.Universal_String is
+   function Fix_Wikilink (Target : League.Strings.Universal_String) return
+      League.Strings.Universal_String
+   is
    begin
       if Target.Starts_With ("w:") then
          return Wiki & Target.Tail_From (3);
@@ -218,28 +223,43 @@ procedure Aqs2mdx is
       end if;
    end Fix_Wikilink;
 
-   function Is_Direct_URL ( Link_Content : League.JSON.Arrays.JSON_Array ) return Boolean is
-      Alt_List : League.JSON.Arrays.JSON_Array := Link_Content (2).To_Array;
-      Target_Tuple : League.JSON.Arrays.JSON_Array := Link_Content (3).To_Array;
-      Target : League.Strings.Universal_String := Target_Tuple (1).To_String;
+   function Is_Direct_URL (Content : League.JSON.Arrays.JSON_Array) return
+     Boolean
+   is
+      Alt_List : constant League.JSON.Arrays.JSON_Array :=
+        Content (2).To_Array;
+      Target_Tuple : constant League.JSON.Arrays.JSON_Array :=
+        Content (3).To_Array;
+      Target : constant League.Strings.Universal_String :=
+        Target_Tuple (1).To_String;
    begin
       if Alt_List.Length /= 1 then
          return False;
       else
          declare
-            Alt_Text_Object : League.JSON.Objects.JSON_Object := Alt_List (1).To_Object;
-            Alt_Text : League.Strings.Universal_String := Alt_Text_Object(Pandoc.Content_String).To_String;
+            Alt_Text_Object : constant League.JSON.Objects.JSON_Object :=
+              Alt_List (1).To_Object;
+            Alt_Text : constant League.Strings.Universal_String :=
+              Alt_Text_Object (Pandoc.Content_String).To_String;
          begin
             return Alt_Text = Target;
          end;
       end if;
    end Is_Direct_URL;
 
-   function Create_String ( Data : League.Strings.Universal_String ) return League.JSON.Values.JSON_Value is
-      Block : League.JSon.Objects.JSON_Object;
+   function Create_String (Data : League.Strings.Universal_String) return
+      League.JSON.Values.JSON_Value
+   is
+      Block : League.JSON.Objects.JSON_Object;
    begin
-      Block.Insert (Pandoc.Type_String, League.JSON.Values.To_JSON_Value (+"Str"));
-      Block.Insert (Pandoc.Content_String, League.JSON.Values.To_JSON_Value (Data));
+      Block.Insert (
+         Pandoc.Type_String,
+         League.JSON.Values.To_JSON_Value (Pandoc.To_String (Inline_String))
+      );
+      Block.Insert (
+         Pandoc.Content_String,
+         League.JSON.Values.To_JSON_Value (Data)
+      );
 
       return Block.To_JSON_Value;
    end Create_String;
@@ -254,8 +274,8 @@ procedure Aqs2mdx is
       Copy : League.JSON.Objects.JSON_Object := Block;
       Args : League.JSON.Arrays.JSON_Array := Copy (+"c").To_Array;
       Link  : League.JSON.Arrays.JSON_Array := Args (3).To_Array;
-      Target : League.Strings.Universal_String := Link (1).To_String;
-      Title : League.Strings.Universal_String := Link (2).To_String;
+      Target : constant League.Strings.Universal_String := Link (1).To_String;
+      Title : constant League.Strings.Universal_String := Link (2).To_String;
    begin
 
       if Title = +"wikilink" then

--- a/source/pandoc.adb
+++ b/source/pandoc.adb
@@ -50,7 +50,7 @@ package body Pandoc is
       Block.Insert (
          Type_String,
          League.JSON.Values.To_JSON_Value (
-            Obj_String_Representation (Block_Div)
+            To_String (Block_Div)
          )
       );
 
@@ -80,7 +80,7 @@ package body Pandoc is
       Block.Insert (
          Type_String,
          League.JSON.Values.To_JSON_Value (
-            Obj_String_Representation (Block_Div)
+            To_String (Block_Div)
          )
       );
 
@@ -106,7 +106,7 @@ begin
    for Key in Object_Type loop
       declare
          Str_Rep : constant League.Strings.Universal_String :=
-           Obj_String_Representation (Key);
+           To_String (Key);
       begin
          Type_Mapping.Insert (Str_Rep, Key);
       end;

--- a/source/pandoc.adb
+++ b/source/pandoc.adb
@@ -98,6 +98,9 @@ package body Pandoc is
    function Get_Type (B : League.JSON.Objects.JSON_Object)
      return Object_Type is (Type_Mapping (B (Type_String).To_String));
 
+   function To_String (T : Object_Type) return League.Strings.Universal_String
+     is (Obj_String_Representation (T));
+
 begin
 
    for Key in Object_Type loop

--- a/source/pandoc.ads
+++ b/source/pandoc.ads
@@ -51,6 +51,8 @@ package Pandoc is
 
    function Get_Type (B : League.JSON.Objects.JSON_Object) return Object_Type;
 
+   function To_String (T : Object_Type) return League.Strings.Universal_String;
+
    function "+" (T : Wide_Wide_String) return League.Strings.Universal_String
      renames League.Strings.To_Universal_String;
 


### PR DESCRIPTION
# What is the problem
Currently, 'naked' URLS (without Alt text) are rendered by pandoc to `<URL>`. MDX does not
support `<URL>` and instead just wants a 'naked' URL: `URL`.

# what is changed by this pull request.
This change adds some code to the `Traverse_Link` function to detect a 'naked' URL and convert
it to a plain text object whilst still allowing the previous code to fix any wikilink issues.

I also added a wrapper around the pandoc type mapping to make it a little easier to use.